### PR TITLE
Enable the Run Workflow button on the Actions tab

### DIFF
--- a/.github/workflows/SBCL-test.yml
+++ b/.github/workflows/SBCL-test.yml
@@ -8,6 +8,9 @@ on:
   pull_request:
     branches: [ master ]
 
+  # Enable the Run Workflow button on the Actions tab.
+  workflow_dispatch:
+
 jobs:
   test:
     runs-on: ubuntu-20.04


### PR DESCRIPTION
This should enable the Run Workflow button on the Actions tab, which may be useful for debugging.